### PR TITLE
To make the images appear in the new repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # Values for this lesson.
 #------------------------------------------------------------
 
-baseurl: /2019-08-19-usatlas-computing-bootcamp
+baseurl: /continuous-integration-deployment-gitlab
 
 # Which carpentry is this ("swc", "dc", "lc", or "cp")?
 # swc: Software Carpentry


### PR DESCRIPTION
This fixes the base URL so that the images/pictures appear in the compiled web page

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
